### PR TITLE
statsd: fix packet size default check

### DIFF
--- a/src/main/java/com/timgroup/statsd/ChannelTransportType.java
+++ b/src/main/java/com/timgroup/statsd/ChannelTransportType.java
@@ -1,0 +1,19 @@
+package com.timgroup.statsd;
+
+public enum ChannelTransportType {
+    UDP("udp"),
+    NAMEDPIPE("namedpipe"),
+    UDS("uds"),
+    UDSSTREAM("uds-stream");
+
+    private final String text;
+
+    ChannelTransportType(final String text) {
+        this.text = text;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+}

--- a/src/main/java/com/timgroup/statsd/ClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/ClientChannel.java
@@ -3,5 +3,5 @@ package com.timgroup.statsd;
 import java.nio.channels.WritableByteChannel;
 
 interface ClientChannel extends WritableByteChannel {
-    String getTransportType();
+    ChannelTransportType getTransportType();
 }

--- a/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/DatagramClientChannel.java
@@ -44,8 +44,8 @@ class DatagramClientChannel implements ClientChannel {
     }
 
     @Override
-    public String getTransportType() {
-        return "udp";
+    public ChannelTransportType getTransportType() {
+        return ChannelTransportType.UDP;
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/NamedPipeClientChannel.java
@@ -40,8 +40,8 @@ class NamedPipeClientChannel implements ClientChannel {
     }
 
     @Override
-    public String getTransportType() {
-        return "namedpipe";
+    public ChannelTransportType getTransportType() {
+        return ChannelTransportType.NAMEDPIPE;
     }
 
     @Override

--- a/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
+++ b/src/main/java/com/timgroup/statsd/NonBlockingStatsDClientBuilder.java
@@ -236,13 +236,7 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
             throw new UnsupportedOperationException("clone");
         }
 
-        int packetSize = maxPacketSizeBytes;
         Callable<SocketAddress> lookup = getAddressLookup();
-
-        if (packetSize == 0) {
-            packetSize = (port == 0) ? NonBlockingStatsDClient.DEFAULT_UDS_MAX_PACKET_SIZE_BYTES :
-                NonBlockingStatsDClient.DEFAULT_UDP_MAX_PACKET_SIZE_BYTES;
-        }
 
         Callable<SocketAddress> telemetryLookup = telemetryAddressLookup;
         if (telemetryLookup == null) {
@@ -253,7 +247,6 @@ public class NonBlockingStatsDClientBuilder implements Cloneable {
             }
         }
 
-        resolved.maxPacketSizeBytes = packetSize;
         resolved.addressLookup = lookup;
         resolved.telemetryAddressLookup = telemetryLookup;
 

--- a/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixDatagramClientChannel.java
@@ -28,7 +28,7 @@ class UnixDatagramClientChannel extends DatagramClientChannel {
     }
 
     @Override
-    public String getTransportType() {
-        return "uds";
+    public ChannelTransportType getTransportType() {
+        return ChannelTransportType.UDS;
     }
 }

--- a/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
+++ b/src/main/java/com/timgroup/statsd/UnixStreamClientChannel.java
@@ -167,8 +167,8 @@ public class UnixStreamClientChannel implements ClientChannel {
     }
 
     @Override
-    public String getTransportType() {
-        return "uds-stream";
+    public ChannelTransportType getTransportType() {
+        return ChannelTransportType.UDSSTREAM;
     }
 
     @Override


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-10667

Currently, the logic for setting the size of the packets depends on the value of `port`.

However, when using UDS stream via `address()`, `port` is no longer set and defaults to 8125. This means that the size of the packet for UDS stream will default to `DEFAULT_UDP_MAX_PACKET_SIZE_BYTES`, which is 8 times smaller than the `DEFAULT_UDS_MAX_PACKET_SIZE_BYTES`, which introduces unnecessary overhead.

This PR introduces a new `isUDStransport` boolean that is set to true when using UDS for the main address (not for the telemetry address), and this is used to pick up the default max size of packets.